### PR TITLE
handle google.com/url links and other urls that redirect to drive.google.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 .temp/
 .censored/
 settings.toml
+.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -163,4 +163,4 @@ cython_debug/
 .temp/
 .censored/
 settings.toml
-.vscode/*
+.vscode/

--- a/src/itg_cli/_utils.py
+++ b/src/itg_cli/_utils.py
@@ -95,11 +95,12 @@ def download_file(url: str, downloads: Path) -> Path:
     # TODO: handle mega.nz links
     parsed_url = urlparse(url)
     if "google.com" in parsed_url.netloc and "/url" in parsed_url.path:
+        # follow redirects from google sheets links
         parsed_query = parse_qs(parsed_url.query)
         url = parsed_query["q"][0]
         parsed_url = urlparse(url)
         print(f"Redirecting to {url}...", file=sys.stderr)
-    if "drive.google.com" in url or "drive.usercontent.google.com" in url:
+    if "drive.google.com" in parsed_url.netloc or "drive.usercontent.google.com" in parsed_url.netloc:
         print("Making request to Google Drive...", file=sys.stderr)
         download_path = gdown.download(
             url,


### PR DESCRIPTION
## Description
Parse "q" parameter of all google.com/url?q=... links and handle that accordingly

Make request to Google Drive if the redirected url is drive.google.com

## Motivation and Context
All links in the itg packs spreadsheet are google.com/url?q=... links, which don't actually redirect to the actual link
(this only applies to the htmlview link, but that's where itgpacks.com redirects to)

Also, redirected urls are always handled by default behavior (simple requests.get), which breaks add-pack/song functionality if the link redirects to drive.google.com

## How Has This Been Tested?
works with [kpoop](https://www.google.com/url?q=https://drive.google.com/file/d/1o1qo8DGSLWTEC5YDIBcADucmqH3NwGNL/view?usp%3Ddrive_link&sa=D&source=editors&ust=1744670365900074&usg=AOvVaw03zih4qPI53LTAwsJ83SzH) (google.com/url) and [egg carton 3](https://bit.ly/eggcarton3-dl) (bit.ly that redirects to drive.google.com)